### PR TITLE
Fix: Correctly escape characters in setup_gallery.sh

### DIFF
--- a/setup_gallery.sh
+++ b/setup_gallery.sh
@@ -226,7 +226,7 @@ app.listen(port, async () => {
     try {
         const baseDir = process.env.SMB_DIRECTORY_PATH || '/';
         imageIndex = await findImages(baseDir);
-        console.log(\`Found \${imageIndex.length} images.`);
+        console.log(\`Found \${imageIndex.length} images.\`);
     } catch (err) {
         console.error("Failed to connect to SMB share or index images on startup.", err);
         // We will let the server run, it might recover or the user might fix config


### PR DESCRIPTION
The setup script was failing with a 'bad substitution' error due to unescaped backticks in the JavaScript code being generated. This change escapes the backticks to ensure the script runs correctly.

Also, removed generated backend/ and frontend/ directories.